### PR TITLE
mod wp-pull-production-db to accomodate multisite.

### DIFF
--- a/roles/scripts/files/wp-pull-production-db
+++ b/roles/scripts/files/wp-pull-production-db
@@ -39,4 +39,4 @@ system "ssh -q #{username}@#{host} -p #{port} 'wp db export - --single-transacti
 
 # Search Replace all but guid because guid is just a name for post
 puts "Search-replacing #{siteurl_production} with #{siteurl_development} --skip-columns=guid"
-system "wp search-replace #{siteurl_production} #{siteurl_development}"
+system "wp search-replace #{siteurl_production} #{siteurl_development} --skip-columns=guid --network --url=#{siteurl_production}"


### PR DESCRIPTION
Allow script wp-pull-production-db to work not only in single but also a network install. Implement --skip-columns as advertised but not implemented.

The --network arg does not disallow use in single installs.
