### PR TITLE
Upgrade to node 7 and add yarn

### DIFF
--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set up Node.js
-  command: bash -c "curl -sL https://deb.nodesource.com/setup_4.x | bash -"
+  command: bash -c "curl -sL https://deb.nodesource.com/setup_7.x | bash -"
 
 - name: Install Node.js
   apt: pkg=nodejs state=installed
@@ -8,6 +8,7 @@
 - name: Install some NPM Packages
   npm: name="{{ item }}" global=yes state=latest
   with_items:
+    - yarn
     - bower
     - gulp-cli
     - grunt-cli


### PR DESCRIPTION
Node 7 is now stable. We should start using that in production instances and our vagrant dev box by default.

Commit comes also with the addition of yarn, which is currently industry standard and widely supported by other platforms like Heroku and Travis.