### PR TITLE
WIP: Extend Travis-CI to run test provisioning as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,28 @@
+---
+dist: bionic
 language: python
-os: linux
 
-cache: pip
+cache:
+  directories:
+  - /home/travis/.vagrant.d/boxes
 
 install:
   - curl -Os https://raw.githubusercontent.com/Seravo/gnitpick/master/gnitpick.py
   - pip install ansible
+
+  # Install libvrt & KVM
+  # See https://github.com/jonashackt/vagrant-travisci-libvrt/blob/master/.travis.yml and https://github.com/alvistack/ansible-role-virtualbox/blob/master/.travis.yml
+  - sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils ruby-dev ansible
+
+  # Download Vagrant & Install Vagrant package
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.deb
+  - sudo dpkg -i vagrant_2.2.7_x86_64.deb
+
+  # Vagrant correctly installed?
+  - vagrant --version
+
+  # Install vagrant-libvirt Vagrant plugin
+  - sudo vagrant plugin install vagrant-libvirt
 
 script:
   # Abort immediately if one step fails
@@ -15,4 +32,9 @@ script:
   # Run our custom Git commit checks
   - python3 ./gnitpick.py --target-repository https://github.com/seravo/wp-vagrant.git
 
+  # Lint Ansible
+  - sed 's|ubuntu/bionic64|generic/ubuntu1804|' -i Vagrantfile
   - ansible-playbook --syntax-check -i hosts/development site.yml
+
+  # Build and test everything
+  - sudo vagrant up --provision --provider=libvirt

--- a/roles/cleanup/files/cleanup.sh
+++ b/roles/cleanup/files/cleanup.sh
@@ -1,20 +1,14 @@
 #!/bin/sh
 
+# Some Vagrant boxes have sda1, others vda1
+ROOT_FS_DEVICE=$(mount / 2>&1 | grep -o -e '/dev/[a-z0-9]*')
+
 # Run zerofree
 echo "u" > /proc/sysrq-trigger
-mount / -o remount,ro
+mount -o remount,ro /
 
-# Some Vagrant boxes have sda1, others vda1
-if [ -e /dev/sda1 ]
-then
-  zerofree -v /dev/sda1
-elif [ -e /dev/vda1 ]
-then
-  zerofree -v /dev/vda1
-else
-  echo "ERROR: Root filesystem not found at any of the expected locations"
-  exit 1
-fi
+zerofree -v "$ROOT_FS_DEVICE"
 
-# Mount writeable again, otherwise Ansible will error
-mount / -o remount,rw
+# Try to mount writeable again, otherwise Ansible will error. This does however
+# not work on libvirt where it seems only a reboot makes / writeable again
+mount -o remount,rw / || true


### PR DESCRIPTION
Bug:
Fails on
`  zerofree: filesystem /dev/vda1 is mounted rw`

See https://travis-ci.com/github/Seravo/wp-vagrant/builds/187003547